### PR TITLE
Issue36 after school

### DIFF
--- a/mbp-user-import_manageData.config.inc
+++ b/mbp-user-import_manageData.config.inc
@@ -13,7 +13,7 @@ require_once __DIR__ . '/messagebroker-config/mb-secure-config.inc';
 
 define("ALLOWED_SOURCES", serialize([
   'Niche',
-  'afterSchool'
+  'AfterSchool'
 ]));
 
 $mbConfig = MB_Configuration::getInstance();

--- a/src/MBP_UserCSVfileTools.php
+++ b/src/MBP_UserCSVfileTools.php
@@ -60,9 +60,9 @@ class MBP_UserCSVfileTools
         'from' => 'no-reply@batchrobot.com',
         'subject' => 'Niche-DoSomething Daily Co-regs',
       ],
-      'afterSchool' => [
-        'from' => '',
-        'subject' => '',
+      'AfterSchool' => [
+        'from' => 'updates@afterschoolapp.com',
+        'subject' => 'AfterSchool-DoSomething Daily Co-regs',
       ],
     ];
 

--- a/src/MBP_UserImport_BaseSource.php
+++ b/src/MBP_UserImport_BaseSource.php
@@ -71,6 +71,9 @@ abstract class MBP_UserImport_BaseSource
   
   /**
    * Logic to determine if data from row in CSV file can be processed.
+   *
+   * @param array $data
+   *   Values to test.
    */
   abstract public function canProcess($data);
 

--- a/src/MBP_UserImport_BaseSource.php
+++ b/src/MBP_UserImport_BaseSource.php
@@ -57,7 +57,7 @@ abstract class MBP_UserImport_BaseSource
    * @param array $message
    *   The message to process by the service from the connected queue.
    */
-  public function __construct($message) {
+  public function __construct() {
 
     $this->mbConfig = MB_Configuration::getInstance();
     $this->statHat = $this->mbConfig->getProperty('statHat');
@@ -69,6 +69,16 @@ abstract class MBP_UserImport_BaseSource
    */
   abstract protected function setKeys();
   
+  /**
+   * Logic to determine if data from row in CSV file can be processed.
+   */
+  abstract public function canProcess($data);
+
+  /**
+   * Assign columns specific to the source to common columns expected by the consumer.
+   */
+  abstract public function setter(&$data);
+
   /**
    * Logic to process CSV file based on column / line endings.
    */

--- a/src/MBP_UserImport_Producer.php
+++ b/src/MBP_UserImport_Producer.php
@@ -81,8 +81,8 @@ class MBP_UserImport_Producer extends MB_Toolbox_BaseProducer
       $targetCSVFileName = $targetFilePaths[count($targetFilePaths) - 1];
     }
     else {
-      $targetCSVFile = __DIR__ . '/../data/' . $source . '/' . $targetCSVFile;
       $targetCSVFileName = $targetCSVFile;
+      $targetCSVFile = __DIR__ . '/../data/' . $source . '/' . $targetCSVFile;
     }
 
     // Is there a file found?
@@ -111,9 +111,10 @@ class MBP_UserImport_Producer extends MB_Toolbox_BaseProducer
       $data['source'] = $source;
       $data['source_file'] = $targetCSVFileName;
 
-      // email Required, create message for user row
-      if (isset($data['email']) && $data['email'] != '') {
+      // Check for required fields based on the source
+      if ($this->source->canProcess($data)) {
 
+        $this->source->setter($data);
         $payload = parent::generatePayload($data);
         $payload = parent::produceMessage($payload, 'userImport');
         

--- a/src/MBP_UserImport_Source_AfterSchool.php
+++ b/src/MBP_UserImport_Source_AfterSchool.php
@@ -17,6 +17,7 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
 {
 
   const USER_COUNTRY = 'US';
+  const MOBILE_OPT_IN_PATH_ID = 200527;
 
   /**
    * Supported key / columns in CSV file from source.
@@ -91,7 +92,7 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
 
     // Send all numbers to US mobile service
     // Mobile Commons opt-in path when user registers for site
-    $message['mobile_opt_in_path_id'] = 164905;
+    $message['mobile_opt_in_path_id'] = self::MOBILE_OPT_IN_PATH_ID;
 
     // Wipe data values with formatted $message values
     $data = $message;

--- a/src/MBP_UserImport_Source_AfterSchool.php
+++ b/src/MBP_UserImport_Source_AfterSchool.php
@@ -69,7 +69,7 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
   public function setter(&$data) {
 
     $message = [];
-    $message['mobile'] = (int) str_replace("'",'', $data['SentToPhone']);
+    $message['mobile'] = str_replace("'",'', $data['SentToPhone']);
 
     $data['SenderName'] = str_replace("'",'', $data['SenderName']);
     $nameBits = explode(' ',$data['SenderName']);

--- a/src/MBP_UserImport_Source_AfterSchool.php
+++ b/src/MBP_UserImport_Source_AfterSchool.php
@@ -16,6 +16,8 @@ use DoSomething\MB_Toolbox\MB_Configuration;
 class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
 {
 
+  const USER_COUNTRY = 'US';
+
   /**
    * Supported key / columns in CSV file from source.
    */
@@ -85,7 +87,7 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
     $message['hs_id'] = (int) str_replace("'",'', $data['SchoolID']);
 
     // All After School users are assumed to be from the United States.
-    $message['user_country'] = 'US';
+    $message['user_country'] = self::USER_COUNTRY;
 
     // Send all numbers to US mobile service
     // Mobile Commons opt-in path when user registers for site

--- a/src/MBP_UserImport_Source_AfterSchool.php
+++ b/src/MBP_UserImport_Source_AfterSchool.php
@@ -98,19 +98,19 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
   /**
    * Logic to process CSV file based on column / line endings.
    *
-   * @param array $CSVRow
+   * @param array $csvRow
    *   A row of user data from the CSV file.
    *
    * @return array $data
    *   CSV values formatted into an array.
    */
-  public function process($CSVRow) {
+  public function process($csvRow) {
 
-    $CSVData = explode(',', $CSVRow);
+    $csvData = explode(',', $csvRow);
     $data = array();
     foreach ($this->keys as $signupIndex => $signupKey) {
-      if (isset($CSVData[$signupIndex]) && $CSVData[$signupIndex] != '') {
-        $data[$signupKey] = $CSVData[$signupIndex];
+      if (isset($csvData[$signupIndex]) && $csvData[$signupIndex] != '') {
+        $data[$signupKey] = $csvData[$signupIndex];
       }
     }
 

--- a/src/MBP_UserImport_Source_AfterSchool.php
+++ b/src/MBP_UserImport_Source_AfterSchool.php
@@ -19,15 +19,82 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
   /**
    * Supported key / columns in CSV file from source.
    */
-  private function setKeys() {
+  protected function setKeys() {
 
     $keys = [
-      '???',
+      'SentToPhone',
+      'SenderName',
+      'ReceiverName',
+      'SchoolID',
+      'SchoolName',
+      'SchoolShort',
+      'SchoolAbbreviation',
+      'Message'
     ];
 
     return $keys;
   }
   
+  /**
+   * Logic to determine if data from row in After School CSV file can be processed.
+   *
+   * @param array $data
+   *   Values being processed from row of data in CSV file.
+   */
+  public function canProcess($data) {
+
+    if (empty($data['SentToPhone'])) {
+      return false;
+    }
+
+    // Validate phone number based on the North American Numbering Plan
+    // https://en.wikipedia.org/wiki/North_American_Numbering_Plan
+    $regex = "/^(\d[\s-]?)?[\(\[\s-]{0,2}?\d{3}[\)\]\s-]{0,2}?\d{3}[\s-]?\d{4}$/i";
+    $mobile = str_replace("'", '', $data['SentToPhone']);
+    if (!(preg_match( $regex, $mobile))) {
+      echo '** canProcess(): Invalid phone number based on North American Numbering Plan standard: ' .  $mobile, PHP_EOL;
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Assign columns specific to the After School CSV file to common columns expected
+   * by the consumer.
+   *
+   * @param array $data
+   *   Values collected from the CSV file for assignment to expected indexes in the consumer.
+   */
+  public function setter(&$data) {
+
+    $message = [];
+    $message['mobile'] = (int) str_replace("'",'', $data['SentToPhone']);
+
+    $data['SenderName'] = str_replace("'",'', $data['SenderName']);
+    $nameBits = explode(' ',$data['SenderName']);
+    if (count($nameBits) > 1) {
+      $message['last_name'] = array_pop($nameBits);
+      $message['first_name'] = implode(' ', $nameBits);
+    }
+    else {
+      $message['first_name'] = $nameBits[0];
+    }
+
+    $message['hs_name'] = str_replace("'",'', $data['SchoolShort']);
+    $message['hs_id'] = (int) str_replace("'",'', $data['SchoolID']);
+
+    // All After School users are assumed to be from the United States.
+    $message['user_country'] = 'US';
+
+    // Send all numbers to US mobile service
+    // Mobile Commons opt-in path when user registers for site
+    $message['mobile_opt_in_path_id'] = 164905;
+
+    // Wipe data values with formatted $message values
+    $data = $message;
+  }
+
   /**
    * Logic to process CSV file based on column / line endings.
    *
@@ -38,6 +105,14 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
    *   CSV values formatted into an array.
    */
   public function process($CSVRow) {
+
+    $CSVData = explode(',', $CSVRow);
+    $data = array();
+    foreach ($this->keys as $signupIndex => $signupKey) {
+      if (isset($CSVData[$signupIndex]) && $CSVData[$signupIndex] != '') {
+        $data[$signupKey] = $CSVData[$signupIndex];
+      }
+    }
 
     return $data;
   }

--- a/src/MBP_UserImport_Source_Niche.php
+++ b/src/MBP_UserImport_Source_Niche.php
@@ -17,6 +17,8 @@ class MBP_UserImport_Source_Niche extends MBP_UserImport_BaseSource
 {
 
   const USER_COUNTRY = 'US';
+  const MOBILE_OPT_IN_PATH_ID = 164905;
+  const MAILCHIMP_LIST_ID = 'f2fab1dfd4';
 
   /**
    * Supported key / columns in CSV file from source.
@@ -95,10 +97,10 @@ class MBP_UserImport_Source_Niche extends MBP_UserImport_BaseSource
 
     // Send all numbers to US mobile service
     // Mobile Commons opt-in path when user registers for site
-    $data['mobile_opt_in_path_id'] = '164905';
+    $data['mobile_opt_in_path_id'] = self::MOBILE_OPT_IN_PATH_ID;
 
     // General MailChimp list for US users.
-    $data['mailchimp_list_id'] = 'f2fab1dfd4';
+    $data['mailchimp_list_id'] = self::MAILCHIMP_LIST_ID;
   }
 
   /**

--- a/src/MBP_UserImport_Source_Niche.php
+++ b/src/MBP_UserImport_Source_Niche.php
@@ -17,21 +17,6 @@ class MBP_UserImport_Source_Niche extends MBP_UserImport_BaseSource
 {
 
   /**
-   * A list of supported keys in the CSV file provided by the source.
-   *
-   * @var array
-   */
-  protected $keys;
-
-  /**
-   * Constructor for MBC_UserImport_Cource_niche - create properties based on setKey method.
-   */
-  public function __construct() {
-
-    $this->keys = $this->setKeys();
-  }
-
-  /**
    * Supported key / columns in CSV file from source.
    */
   protected function setKeys() {
@@ -65,7 +50,49 @@ class MBP_UserImport_Source_Niche extends MBP_UserImport_BaseSource
 
     return $keys;
   }
-  
+
+  /**
+   * Assign columns specific to the Niche CSV file to common columns expected
+   * by the consumer.
+   *
+   * @param array $data
+   *   Values collected from the CSV file for assignment to expected indexes in
+   *   the consumer.
+   */
+  public function canProcess($data) {
+
+    if (empty($data['email'])) {
+      return false;
+    }
+
+    if (filter_var($data['email'], FILTER_VALIDATE_EMAIL) === false) {
+      echo '- canProcess(), failed FILTER_VALIDATE_EMAIL: ' . $data['email'], PHP_EOL;
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Assign columns specific to the Niche CSV file to common columns expected
+   * by the consumer.
+   *
+   * @param array $data
+   *   Values collected from the CSV file for assignment to expected indexes in the consumer.
+   */
+  public function setter(&$data) {
+
+    // All niche users are assumed to be from the United States.
+    $data['user_country'] = 'US';
+
+    // Send all numbers to US mobile service
+    // Mobile Commons opt-in path when user registers for site
+    $data['mobile_opt_in_path_id'] = '164905';
+
+    // General MailChimp list for US users.
+    $data['mailchimp_list_id'] = 'f2fab1dfd4';
+  }
+
   /**
    * Logic to process CSV file based on column / line endings.
    *
@@ -87,16 +114,6 @@ class MBP_UserImport_Source_Niche extends MBP_UserImport_BaseSource
         $data[$signupKey] = $CSVData[$signupIndex];
       }
     }
-
-    // All niche users are assumed to be from the United States.
-    $data['user_country'] = 'US';
-
-    // Send all numbers to US mobile service
-    // Mobile Commons opt-in path when user registers for site
-    $data['mobile_opt_in_path_id'] = '164905';
-
-    // General MailChimp list for US users.
-    $data['mailchimp_list_id'] = 'f2fab1dfd4';
 
     return $data;
   }

--- a/src/MBP_UserImport_Source_Niche.php
+++ b/src/MBP_UserImport_Source_Niche.php
@@ -16,6 +16,8 @@ use DoSomething\MB_Toolbox\MB_Configuration;
 class MBP_UserImport_Source_Niche extends MBP_UserImport_BaseSource
 {
 
+  const USER_COUNTRY = 'US';
+
   /**
    * Supported key / columns in CSV file from source.
    */
@@ -58,6 +60,9 @@ class MBP_UserImport_Source_Niche extends MBP_UserImport_BaseSource
    * @param array $data
    *   Values collected from the CSV file for assignment to expected indexes in
    *   the consumer.
+   *
+   * @return boolean
+   *   Did the canProcess test fail or pass.
    */
   public function canProcess($data) {
 
@@ -79,11 +84,14 @@ class MBP_UserImport_Source_Niche extends MBP_UserImport_BaseSource
    *
    * @param array $data
    *   Values collected from the CSV file for assignment to expected indexes in the consumer.
+   *
+   * @return array &$data
+   *   Supplemented $data var with additional settings.
    */
   public function setter(&$data) {
 
     // All niche users are assumed to be from the United States.
-    $data['user_country'] = 'US';
+    $data['user_country'] = self::USER_COUNTRY;
 
     // Send all numbers to US mobile service
     // Mobile Commons opt-in path when user registers for site


### PR DESCRIPTION
Fixes #36 

- Adds support for After School as a user import source. 
- Additional abstracting of the base classes to better support multiple source classes
- Add `AfterSchool` to `ALLOWED_SOURCES`
- Add `data\AfterSchool` to download CSV files from Google email (machines@dosomething.org) account.

**To Test**:
- Point to `mbp-user-import.php?targetFile=2015-02-05-13-17-00.csv&source=AfterSchool`
- `2015-02-05-13-17-00.csv` can be found at `/opt/rabbit/mbp-user-import/data/AfterSchool` on the `mbc-php` server.

**Expected Results**:
- A message in userImportQueue:
```
{"mobile":5555555555,"last_name":"Blow","first_name":"Joe","hs_name":"DoSomething","hs_id":11500000000001,"user_country":"US","mobile_opt_in_path_id":164905,"requested":"2016-02-08T13:04:21-05:00","startTime":"2016-02-08T13:04:15-05:00"}
```
```
{
"mobile":5555555555,
"last_name":"Blow",
"first_name":"Joe",
"hs_name":"DoSomething",
"hs_id":11500000000001,
"user_country":"US",
"mobile_opt_in_path_id":164905,
"requested":"2016-02-08T13:04:21-05:00",
"startTime":"2016-02-08T13:04:15-05:00"
}
```
- A message in loggingGatewayQueue:
```
{"log-type":"file-import","log-timestamp":1454954661,"signup-count":1,"skipped":0,"source":"AfterSchool","target-CSV-file":"2016-02-05-13-17-00.csv"}
```
```
{
"log-type":"file-import",
"log-timestamp":1454954661,
"signup-count":1,
"skipped":0,
"source":"AfterSchool",
"target-CSV-file":"2016-02-05-13-17-00.csv"
}
```

**Related**:
- https://github.com/DoSomething/mbc-user-import/issues/51