### PR TITLE
Add optin to produced message for After School users

### DIFF
--- a/src/MBP_UserImport_Source_AfterSchool.php
+++ b/src/MBP_UserImport_Source_AfterSchool.php
@@ -18,6 +18,8 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
 
   const USER_COUNTRY = 'US';
   const MOBILE_OPT_IN_PATH_ID = 200527;
+  const AFTERSCHOOL_OPTIN_SINGLE = 'SOLO';
+  const AFTERSCHOOL_OPTIN_DOUBLE = 'PAIR';
 
   /**
    * Supported key / columns in CSV file from source.
@@ -95,11 +97,11 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
     $message['hs_name'] = str_replace('"','', $data['SchoolShort']);
     $message['hs_id'] = (int) str_replace('"','', $data['SchoolID']);
     $optin = str_replace('"','', $data['Optin']);
-    if ($optin == 'SINGLE_OPT_IN') {
-      $message['optin'] = 'SOLO';
+    if ($optin === 'SINGLE_OPT_IN') {
+      $message['optin'] = self::AFTERSCHOOL_OPTIN_SINGLE;
     }
-    elseif ($optin == 'DOUBLE_OPT_IN') {
-      $message['optin'] = 'PAIR';
+    elseif ($optin === 'DOUBLE_OPT_IN') {
+      $message['optin'] = self::AFTERSCHOOL_OPTIN_DOUBLE;
     }
     else {
       echo '=> WARNING: optin not set, unsupported value: ' . $optin, PHP_EOL;

--- a/src/MBP_UserImport_Source_AfterSchool.php
+++ b/src/MBP_UserImport_Source_AfterSchool.php
@@ -32,7 +32,8 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
       'SchoolName',
       'SchoolShort',
       'SchoolAbbreviation',
-      'Message'
+      'Message',
+      'Optin',
     ];
 
     return $keys;
@@ -90,8 +91,19 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
       $message['first_name'] = $nameBits[0];
     }
 
+    // User profile custom field values
     $message['hs_name'] = str_replace('"','', $data['SchoolShort']);
     $message['hs_id'] = (int) str_replace('"','', $data['SchoolID']);
+    $message['optin'] = str_replace('"','', $data['Optin']);
+    if ($message['optin'] == 'SINGLE_OPT_IN') {
+      $message['optin'] = 'SOLO';
+    }
+    elseif ($message['optin'] == 'DOUBLE_OPT_IN') {
+      $message['optin'] = 'PAIR';
+    }
+    else {
+      echo '=> WARNING: Unsupported optin value: ' . $message['optin'], PHP_EOL;
+    }
 
     // All After School users are assumed to be from the United States.
     $message['user_country'] = self::USER_COUNTRY;

--- a/src/MBP_UserImport_Source_AfterSchool.php
+++ b/src/MBP_UserImport_Source_AfterSchool.php
@@ -94,15 +94,15 @@ class MBP_UserImport_Source_AfterSchool extends MBP_UserImport_BaseSource
     // User profile custom field values
     $message['hs_name'] = str_replace('"','', $data['SchoolShort']);
     $message['hs_id'] = (int) str_replace('"','', $data['SchoolID']);
-    $message['optin'] = str_replace('"','', $data['Optin']);
-    if ($message['optin'] == 'SINGLE_OPT_IN') {
+    $optin = str_replace('"','', $data['Optin']);
+    if ($optin == 'SINGLE_OPT_IN') {
       $message['optin'] = 'SOLO';
     }
-    elseif ($message['optin'] == 'DOUBLE_OPT_IN') {
+    elseif ($optin == 'DOUBLE_OPT_IN') {
       $message['optin'] = 'PAIR';
     }
     else {
-      echo '=> WARNING: Unsupported optin value: ' . $message['optin'], PHP_EOL;
+      echo '=> WARNING: optin not set, unsupported value: ' . $optin, PHP_EOL;
     }
 
     // All After School users are assumed to be from the United States.


### PR DESCRIPTION
Fixes #38

Add support for `Optin` column for values `SOLO` (`SINGLE_OPT_IN)` or `PAIR (`DOUBLE_OPT_IN`)

- Add `Optin` to supported $keys: https://github.com/DoSomething/mbp-user-import/blob/master/src/MBP_UserImport_Source_AfterSchool.php#L27-L36
- Add `optin` to message: https://github.com/DoSomething/mbp-user-import/blob/master/src/MBP_UserImport_Source_AfterSchool.php#L65-L105

**Related**: All issues will be deployed at the same time.
- https://github.com/DoSomething/mbc-user-import/issues/53
- https://github.com/DoSomething/mbc-registration-mobile/issues/29

**Reference**: CSV columns:
```
"SentToPhone","SenderName","ReceiverName","SchoolID","SchoolName","SchoolShort","SchoolAbbreviation","Message", "Optin"
```